### PR TITLE
fix: corrigir inconsistencias criticas de roteamento do dashboard (#33)

### DIFF
--- a/src/app/middleware/auth-middleware.ts
+++ b/src/app/middleware/auth-middleware.ts
@@ -1,11 +1,17 @@
 import { redirect } from "react-router"
 import { authClient } from "@/lib/client"
+import { getLoginPathWithRedirect } from "../routes/auth/manifest"
 
-export async function authMiddleware() {
+export async function authMiddleware({ request }: { request?: Request } = {}) {
 	const { data } = await authClient.getSession()
 	const userId = data?.user?.id
 
 	if (!userId) {
-		throw redirect("/login")
+		const currentPath = request ? new URL(request.url) : null
+		const redirectPath = currentPath
+			? `${currentPath.pathname}${currentPath.search}${currentPath.hash}`
+			: "/dashboard"
+
+		throw redirect(getLoginPathWithRedirect(redirectPath))
 	}
 }

--- a/src/app/routes/auth/forgot.tsx
+++ b/src/app/routes/auth/forgot.tsx
@@ -5,10 +5,11 @@ import { type SubmitHandler, useForm } from "react-hook-form"
 import { Link, useNavigate } from "react-router"
 import { toast } from "sonner"
 import { Field } from "@/components/form"
+import { Button } from "@/components/ui/button"
 import { authClient } from "@/lib/client"
 import type { ForgotForm } from "@/types/auth"
 import { ForgotFormSchema } from "@/utils/user-validation"
-import { Button } from "@/components/ui/button"
+import { authRoutePaths, sanitizeAuthRedirectPath } from "./manifest"
 
 export default function Forgot() {
 	const navigate = useNavigate()
@@ -28,6 +29,11 @@ export default function Forgot() {
 	})
 
 	const onSubmit: SubmitHandler<ForgotForm> = async (data) => {
+		const redirectTo = sanitizeAuthRedirectPath(
+			data.redirectTo,
+			authRoutePaths.verify
+		)
+
 		try {
 			setLoading(true)
 			await authClient.emailOtp.sendVerificationOtp(
@@ -37,9 +43,9 @@ export default function Forgot() {
 				},
 				{
 					onSuccess() {
-						navigate(data.redirectTo || "/verify", {
+						navigate(redirectTo, {
 							replace: true,
-							state: { redirectTo: "/change-password" },
+							state: { redirectTo: authRoutePaths.changePassword },
 						})
 					},
 				}
@@ -57,7 +63,7 @@ export default function Forgot() {
 		<div className="flex flex-col gap-6" data-slot="auth-forgot">
 			<Link
 				className="absolute top-0 left-0 flex items-center gap-1 text-secondary text-xs transition-colors hover:text-white"
-				to="/login"
+				to={authRoutePaths.login}
 			>
 				<Icon icon="solar:arrow-left-linear" /> Voltar
 			</Link>

--- a/src/app/routes/auth/login.tsx
+++ b/src/app/routes/auth/login.tsx
@@ -2,22 +2,24 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { Icon } from "@iconify-icon/react"
 import { useState } from "react"
 import { type SubmitHandler, useForm } from "react-hook-form"
-import { Link } from "react-router"
+import { Link, useSearchParams } from "react-router"
 import { toast } from "sonner"
 import { useAuth, useAuthAction } from "@/app/store/auth-store"
 import { Field } from "@/components/form"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { usePostHogEvent } from "@/hooks"
 import { sentryCaptureException } from "@/lib/sentry"
 import type { LogInForm } from "@/types/auth"
 import { SignInFormSchema } from "@/utils/user-validation"
-import { Input } from "@/components/ui/input"
+import { authRoutePaths, sanitizeAuthRedirectPath } from "./manifest"
 
 export default function Login() {
 	const [rememberMe, setRememberMe] = useState(false)
 	const { capture } = usePostHogEvent()
 	const { login } = useAuthAction()
 	const { isLoading } = useAuth()
+	const [searchParams] = useSearchParams()
 
 	const {
 		register,
@@ -35,8 +37,10 @@ export default function Login() {
 	})
 
 	const onSubmit: SubmitHandler<LogInForm> = async (data) => {
+		const redirectTo = sanitizeAuthRedirectPath(searchParams.get("redirectTo"))
+
 		try {
-			await login(data.email, data.password, rememberMe)
+			await login(data.email, data.password, rememberMe, redirectTo)
 		} catch (error) {
 			sentryCaptureException(error)
 			toast.error("Falha no login", {
@@ -130,7 +134,7 @@ export default function Login() {
 					</label>
 					<Link
 						className="cursor-pointer text-secondary text-xs transition-colors hover:text-white"
-						to="/forgot"
+						to={authRoutePaths.forgot}
 					>
 						Esqueceu sua senha?
 					</Link>
@@ -152,7 +156,7 @@ export default function Login() {
 				<Link
 					className="cursor-pointer text-white underline-offset-2 hover:underline"
 					onClick={() => capture("link_clicked", { link_name: "register" })}
-					to="/register"
+					to={authRoutePaths.register}
 				>
 					Criar conta
 				</Link>

--- a/src/app/routes/auth/manifest.ts
+++ b/src/app/routes/auth/manifest.ts
@@ -1,0 +1,38 @@
+export const authRouteSegments = {
+	login: "login",
+	register: "register",
+	forgot: "forgot",
+	verify: "verify",
+	changePassword: "change-password",
+} as const
+
+export const authRoutePaths = {
+	login: `/${authRouteSegments.login}`,
+	register: `/${authRouteSegments.register}`,
+	forgot: `/${authRouteSegments.forgot}`,
+	verify: `/${authRouteSegments.verify}`,
+	changePassword: `/${authRouteSegments.changePassword}`,
+	dashboardHome: "/dashboard",
+} as const
+
+export function sanitizeAuthRedirectPath(
+	redirectTo: string | null | undefined,
+	fallback: string = authRoutePaths.dashboardHome
+) {
+	if (!redirectTo) {
+		return fallback
+	}
+
+	if (!redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+		return fallback
+	}
+
+	return redirectTo
+}
+
+export function getLoginPathWithRedirect(redirectTo: string) {
+	const safeRedirect = sanitizeAuthRedirectPath(redirectTo)
+	const params = new URLSearchParams({ redirectTo: safeRedirect })
+
+	return `${authRoutePaths.login}?${params.toString()}`
+}

--- a/src/app/routes/auth/register.tsx
+++ b/src/app/routes/auth/register.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button"
 import { authClient } from "@/lib/client"
 import type { SignUpForm } from "@/types/auth"
 import { SignUpFormSchema } from "@/utils/user-validation"
+import { authRoutePaths, sanitizeAuthRedirectPath } from "./manifest"
 
 export default function Register() {
 	const navigate = useNavigate()
@@ -32,6 +33,11 @@ export default function Register() {
 	})
 
 	const onSubmit: SubmitHandler<SignUpForm> = async (data) => {
+		const redirectTo = sanitizeAuthRedirectPath(
+			data.redirectTo,
+			authRoutePaths.verify
+		)
+
 		try {
 			setLoading(true)
 			await authClient.signUp.email(
@@ -44,7 +50,7 @@ export default function Register() {
 				} as never,
 				{
 					onSuccess() {
-						navigate(data.redirectTo || "/verify", {
+						navigate(redirectTo, {
 							state: { email: data.email, redirectTo: data.redirectTo },
 						})
 					},
@@ -160,7 +166,7 @@ export default function Register() {
 				Já tem uma conta?{" "}
 				<Link
 					className="text-white underline-offset-2 hover:underline"
-					to="/login"
+					to={authRoutePaths.login}
 				>
 					Entrar
 				</Link>

--- a/src/app/routes/auth/verify.tsx
+++ b/src/app/routes/auth/verify.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { Controller, type SubmitHandler, useForm } from "react-hook-form"
 import { Link, useLocation, useNavigate } from "react-router"
 import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
 import {
 	InputOTP,
 	InputOTPGroup,
@@ -14,7 +15,7 @@ import { authClient } from "@/lib/client"
 import type { VerifyForm } from "@/types/auth"
 import { cn } from "@/utils/misc"
 import { VerifyFormSchema } from "@/utils/user-validation"
-import { Button } from "@/components/ui/button"
+import { authRoutePaths, sanitizeAuthRedirectPath } from "./manifest"
 
 export default function Verify() {
 	const location = useLocation()
@@ -38,6 +39,8 @@ export default function Verify() {
 	})
 
 	const onSubmit: SubmitHandler<VerifyForm> = async (data) => {
+		const destination = sanitizeAuthRedirectPath(redirectTo)
+
 		try {
 			setLoading(true)
 			await authClient.emailOtp.verifyEmail(
@@ -47,7 +50,7 @@ export default function Verify() {
 				},
 				{
 					onSuccess() {
-						navigate(redirectTo || "/dashboard", { replace: true })
+						navigate(destination, { replace: true })
 					},
 				}
 			)
@@ -64,7 +67,7 @@ export default function Verify() {
 		<div className="flex flex-col gap-6">
 			<Link
 				className="absolute top-0 left-0 flex items-center gap-1 text-secondary text-xs transition-colors hover:text-white"
-				to="/login"
+				to={authRoutePaths.login}
 			>
 				<Icon icon="solar:arrow-left-linear" /> Voltar
 			</Link>

--- a/src/app/routes/dashboard/addOrg/index.tsx
+++ b/src/app/routes/dashboard/addOrg/index.tsx
@@ -12,17 +12,18 @@ import { useNavigate } from "react-router"
 import { toast } from "sonner"
 import { z } from "zod"
 import { useStepper, useStepperAction } from "@/app/store/stepper-store"
+import { Button } from "@/components/ui/button"
 import { useCities, useCreateAddress } from "@/hooks/useAddress"
 import { authClient } from "@/lib/client"
 import { sentryCaptureException } from "@/lib/sentry"
 import { cn } from "@/utils/misc"
+import { dashboardRoutePaths } from "../manifest"
 import { Concept } from "./components/steps/concept"
 import { Location } from "./components/steps/location"
 import { Operation } from "./components/steps/operation"
 import { StepContent } from "./components/steps/stepper-content"
 import { StepperHeader } from "./components/steps/stepper-header"
 import { StepperRoot } from "./components/steps/stepper-root"
-import { Button } from "@/components/ui/button"
 
 const step1Schema = z.object({
 	ownerName: z.string().min(3, "Nome deve ter pelo menos 3 caracteres"),
@@ -187,7 +188,7 @@ export default function AddOrganization() {
 						toast.success("Organização criada!", {
 							description: "Seu estabelecimento foi criado com sucesso.",
 						})
-						navigate("/dashboard", { replace: true })
+						navigate(dashboardRoutePaths.home, { replace: true })
 						authClient.useActiveOrganization
 					},
 					onError: (err) => {

--- a/src/app/routes/dashboard/components/layout/bottom-nav.tsx
+++ b/src/app/routes/dashboard/components/layout/bottom-nav.tsx
@@ -19,6 +19,7 @@ export function BottomNav() {
 									: "text-surface-400 hover:text-surface-600"
 							)
 						}
+						end={item.key === "home"}
 						key={item.fullPath}
 						to={item.fullPath}
 					>

--- a/src/app/routes/dashboard/components/layout/navbar.tsx
+++ b/src/app/routes/dashboard/components/layout/navbar.tsx
@@ -28,6 +28,7 @@ export function DashboardNavbar({
 							isCollapsed && "lg:justify-center"
 						)
 					}
+					end={item.key === "home"}
 					key={item.fullPath}
 					onClick={onClick}
 					to={item.fullPath}

--- a/src/app/routes/dashboard/components/layout/top-bar.tsx
+++ b/src/app/routes/dashboard/components/layout/top-bar.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react"
 import { useState } from "react"
 import { useNavigate } from "react-router"
+import { authRoutePaths } from "@/app/routes/auth/manifest"
 import { useAuth, useAuthAction } from "@/app/store/auth-store"
 import { useBillingStore } from "@/app/store/billingStore"
 import { useNotificationStore } from "@/app/store/notificationStore"
@@ -61,7 +62,7 @@ export function TopBar() {
 	const handleOnLogout = () => {
 		logout()
 		setIsUserMenuOpen(false)
-		navigate("/login")
+		navigate(authRoutePaths.login)
 	}
 
 	return (
@@ -360,7 +361,7 @@ export function TopBar() {
 									onClick={() => {
 										logout()
 										setIsMobileMenuOpen(false)
-										navigate("/login")
+										navigate(authRoutePaths.login)
 									}}
 									type="button"
 								>

--- a/src/app/routes/dashboard/index.tsx
+++ b/src/app/routes/dashboard/index.tsx
@@ -21,7 +21,11 @@ export default function Dashboard() {
 	}
 
 	if (!hasOrganization && location.pathname !== dashboardRoutePaths.addOrg) {
-		return <Navigate replace to={dashboardRoutePaths.addOrg} />
+		return (
+			<ProtectedRoute>
+				<Navigate replace to={dashboardRoutePaths.addOrg} />
+			</ProtectedRoute>
+		)
 	}
 
 	return (

--- a/src/app/routes/dashboard/pages/tables.tsx
+++ b/src/app/routes/dashboard/pages/tables.tsx
@@ -15,6 +15,7 @@ import { useOrganizationCheck } from "@/hooks/useOrganizationCheck"
 import { sentryCaptureException } from "@/lib/sentry"
 import type { Table } from "@/types/dashboard"
 import { cn } from "@/utils/misc"
+import { dashboardRoutePaths } from "../manifest"
 
 export default function TablesPage() {
 	const { setTableId, setType, clearCart } = useCartStore()
@@ -50,9 +51,9 @@ export default function TablesPage() {
 			clearCart()
 			setTableId(table.id)
 			setType("dine_in")
-			navigate("/dashboard/pos")
+			navigate(dashboardRoutePaths.pos)
 		} else if (table.status === "occupied" && table.currentOrderId) {
-			navigate(`/dashboard/orders?id=${table.currentOrderId}`)
+			navigate(`${dashboardRoutePaths.orders}?id=${table.currentOrderId}`)
 		}
 	}
 

--- a/src/app/routes/error-pages/auth-error.tsx
+++ b/src/app/routes/error-pages/auth-error.tsx
@@ -1,11 +1,12 @@
 import { useNavigate } from "react-router"
 import { Button } from "@/components/ui/button"
+import { authRoutePaths } from "../auth/manifest"
 
 export function AuthErrorPage() {
 	const navigate = useNavigate()
 
 	const handleLogin = () => {
-		navigate("/login")
+		navigate(authRoutePaths.login)
 	}
 
 	return (

--- a/src/app/routes/error-pages/not-found.tsx
+++ b/src/app/routes/error-pages/not-found.tsx
@@ -6,10 +6,10 @@ export function NotFoundPage() {
 		<div className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center">
 			<h1 className="mb-4 font-bold text-6xl text-neutral-900">404</h1>
 			<p className="mb-8 text-lg text-neutral-600">
-				The page you're looking for doesn't exist.
+				A página que você procura não existe.
 			</p>
 			<Link to="/">
-				<Button variant="primary">Go Home</Button>
+				<Button variant="primary">Voltar para o início</Button>
 			</Link>
 		</div>
 	)

--- a/src/app/routes/index.ts
+++ b/src/app/routes/index.ts
@@ -2,8 +2,10 @@ import { lazy } from "react"
 import { createBrowserRouter } from "react-router"
 import { authClient } from "@/lib/client"
 import { authMiddleware } from "../middleware/auth-middleware"
+import { authRouteSegments } from "./auth/manifest"
 import { dashboardRouteSegments } from "./dashboard/manifest"
 import { RouteErrorBoundary } from "./error-boundary"
+import { NotFoundPage } from "./error-pages/not-found"
 
 const HomeLayout = lazy(() => import("../../components/layout/layout"))
 const HomeContent = lazy(() => import("./home"))
@@ -76,11 +78,14 @@ export const router = createBrowserRouter([
 			{
 				Component: AuthLayout,
 				children: [
-					{ path: "login", Component: Login },
-					{ path: "register", Component: Register },
-					{ path: "forgot", Component: Forgot },
-					{ path: "verify", Component: Verify },
-					{ path: "change-password", Component: ChangePassword },
+					{ path: authRouteSegments.login, Component: Login },
+					{ path: authRouteSegments.register, Component: Register },
+					{ path: authRouteSegments.forgot, Component: Forgot },
+					{ path: authRouteSegments.verify, Component: Verify },
+					{
+						path: authRouteSegments.changePassword,
+						Component: ChangePassword,
+					},
 				],
 			},
 		],
@@ -111,7 +116,12 @@ export const router = createBrowserRouter([
 			{ path: dashboardRouteSegments.customers, Component: Customers },
 			{ path: dashboardRouteSegments.menu, Component: MenuBuilder },
 			{ path: dashboardRouteSegments.billing, Component: Billing },
+			{ path: "*", Component: NotFoundPage },
 		],
+	},
+	{
+		path: "*",
+		Component: NotFoundPage,
 	},
 ])
 

--- a/src/app/routes/protected-routes.tsx
+++ b/src/app/routes/protected-routes.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from "react"
 import { Navigate, useLocation } from "react-router"
 import { useAuth } from "../store/auth-store"
+import { getLoginPathWithRedirect } from "./auth/manifest"
 
 export function ProtectedRoute({ children }: PropsWithChildren) {
 	const { isAuthenticated, isLoading } = useAuth()
@@ -15,7 +16,9 @@ export function ProtectedRoute({ children }: PropsWithChildren) {
 	}
 
 	if (!isAuthenticated) {
-		return <Navigate replace state={{ from: location }} to="/login" />
+		const redirectPath = `${location.pathname}${location.search}${location.hash}`
+
+		return <Navigate replace to={getLoginPathWithRedirect(redirectPath)} />
 	}
 
 	return <>{children}</>

--- a/src/app/store/auth-store.ts
+++ b/src/app/store/auth-store.ts
@@ -3,6 +3,7 @@ import { create } from "zustand"
 import { persist } from "zustand/middleware"
 import { authClient } from "@/lib/client"
 import type { User } from "@/types/dashboard"
+import { dashboardRoutePaths } from "../routes/dashboard/manifest"
 
 interface AuthState {
 	user: User | null
@@ -22,7 +23,7 @@ const useAuthStore = create<AuthState>()(
 		(set) => ({
 			user: null,
 			isLoading: false,
-			isAuthenticated: true,
+			isAuthenticated: false,
 			login: async (
 				email: string,
 				password: string,
@@ -34,7 +35,7 @@ const useAuthStore = create<AuthState>()(
 					{
 						email,
 						password,
-						callbackURL: redirectTo || "/dashboard",
+						callbackURL: redirectTo || dashboardRoutePaths.home,
 						rememberMe,
 					},
 					{

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@iconify-icon/react"
 import { Link } from "react-router"
+import { authRoutePaths } from "@/app/routes/auth/manifest"
 
 export function Navbar() {
 	return (
@@ -46,14 +47,14 @@ export function Navbar() {
 					<Link
 						aria-label="Navegar para entrar"
 						className="cursor-pointer font-medium text-slate-400 text-xs transition-colors hover:text-white"
-						to="/login"
+						to={authRoutePaths.login}
 					>
 						Entrar
 					</Link>
 					<Link
 						aria-label="Navegar para criar conta"
 						className="group relative cursor-pointer overflow-hidden rounded-full bg-white/10 px-3 py-1.5 font-medium text-white text-xs transition-all hover:bg-white/15"
-						to="/register"
+						to={authRoutePaths.register}
 					>
 						<span className="relative z-10">Criar Conta</span>
 						<div className="border-beam opacity-0 transition-opacity group-hover:opacity-100" />


### PR DESCRIPTION
## Contexto

Este PR resolve inconsistencias de roteamento do dashboard e do fluxo de autenticacao que podiam causar redirecionamentos incorretos e links desalinhados com o roteador principal.
#33 
## O que mudou

- Criei um manifesto unico de rotas de autenticacao em `src/app/routes/auth/manifest.ts` para remover paths hardcoded.
- Padronizei redirecionamento para login com `redirectTo` sanitizado em rotas protegidas e middleware.
- Alinhei links e navegacao (auth, navbar publica, topbar e paginas do dashboard) para usar constantes de rota.
- Ajustei destaque de rota ativa no menu (match exato para `Dashboard`).
- Adicionei fallback explicito de rota inexistente (`*`) e traduzi a tela 404 para pt-BR.

## Como validar

1. `pnpm build`
2. `pnpm check`
3. Validacao funcional/manual:
   - Acesse `/dashboard/orders` sem sessao e valide redirecionamento para `/login?redirectTo=...`.
   - Faca login e valide retorno para a rota originalmente solicitada.
   - Navegue por sidebar/bottom nav e valide que apenas um item fica ativo por rota.
   - Acesse uma rota inexistente (ex.: `/dashboard/rota-invalida`) e valide fallback 404.

## Checklist geral

- [x] Texto user-facing em pt-BR.
- [x] Sem codigo morto e sem import nao utilizado.
- [x] Sem alteracao fora do escopo.

## Checklist de arquitetura

- [x] Respeita fronteiras `app/domains/shared`.
- [x] Sem import cruzado direto entre dominios.
- [x] Naming e paths seguem `docs/naming.md` e `docs/architecture.md`.
- [x] Tipos cross-domain estao em `shared/types`.
- [x] Quando houve migracao, `docs/architecture.md` foi atualizado.