### PR TITLE
refactor: decompor tipos de dashboard por dominio

### DIFF
--- a/src/app/routes/dashboard/components/layout/dashboard-notification.tsx
+++ b/src/app/routes/dashboard/components/layout/dashboard-notification.tsx
@@ -5,7 +5,7 @@
 import { motion } from "framer-motion"
 import { Bell, X } from "lucide-react"
 import type { MouseEventHandler } from "react"
-import type { Notification } from "@/types/dashboard"
+import type { Notification } from "@/domains/notifications/types/notification-types"
 import { cn } from "@/utils/misc"
 
 interface NotificationProps {

--- a/src/app/routes/dashboard/components/recharts/revenue-chart.tsx
+++ b/src/app/routes/dashboard/components/recharts/revenue-chart.tsx
@@ -9,11 +9,11 @@ import {
 	XAxis,
 	YAxis,
 } from "recharts"
+import type { RevenueChartPoint } from "@/app/routes/dashboard/types/dashboard-analytics-types"
 import { ErrorBoundary } from "@/components/error-boundary"
-import type { Daum } from "@/types/dashboard"
 
 interface RevenueChartProps {
-	data: Daum[]
+	data: RevenueChartPoint[]
 	showOrders?: boolean
 }
 

--- a/src/app/routes/dashboard/data/mock-data.ts
+++ b/src/app/routes/dashboard/data/mock-data.ts
@@ -3,7 +3,7 @@ import type {
 	InventoryItem,
 	MenuItem,
 	SalesData,
-} from "@/types/dashboard"
+} from "@/app/routes/dashboard/types/mock-dashboard-data-types"
 
 export const menuItems: MenuItem[] = [
 	{

--- a/src/app/routes/dashboard/pages/pos.tsx
+++ b/src/app/routes/dashboard/pages/pos.tsx
@@ -22,7 +22,7 @@ import { useCartStore } from "@/domains/pos/store/cart-store"
 import { useRestaurantStore } from "@/domains/restaurant/store/restaurant-store"
 import { useOrganizationCheck } from "@/hooks/use-organization-check"
 import { sentryCaptureException } from "@/lib/sentry"
-import type { PaymentMethod } from "@/types/dashboard"
+import type { PaymentMethod } from "@/shared/types/commerce-types"
 import { formatCurrency } from "@/utils/helpers"
 import { cn } from "@/utils/misc"
 

--- a/src/app/routes/dashboard/types/dashboard-analytics-types.ts
+++ b/src/app/routes/dashboard/types/dashboard-analytics-types.ts
@@ -1,0 +1,106 @@
+import type { Order } from "@/domains/orders/types/order.types"
+import type { Table } from "@/domains/tables/types/table.types"
+
+export interface SalesData {
+	date: string
+	revenue: number
+	orders: number
+	expenses: number
+}
+
+export interface RevenueChartPoint {
+	date: string
+	revenue: number
+	orders: number
+}
+
+interface RevenueSummary {
+	totalRevenue: number
+	percentageChange: number
+}
+
+export interface DashboardRevenue {
+	data: RevenueChartPoint[]
+	summary: RevenueSummary
+}
+
+interface StatsRoot {
+	current: number
+	previous: number
+	percentageChange: number
+}
+
+interface TablesStats {
+	occupied: number
+	total: number
+	percentageChange: number
+}
+
+interface Stats {
+	revenue: StatsRoot
+	orders: StatsRoot
+	tables: TablesStats
+}
+
+interface RecentOrders {
+	total: number
+	orders: Order[]
+}
+
+interface TablesSummary {
+	available: number
+	occupied: number
+	reserved: number
+	cleaning: number
+	total: number
+}
+
+interface TablesStatus {
+	summary: TablesSummary
+	tables: Table[]
+}
+
+interface TopProduct {
+	rank: number
+	id: string
+	name: string
+	category: string
+	price: number
+	quantitySold: number
+}
+
+interface Period {
+	days: number
+	startDate: string
+	endDate: string
+}
+
+export interface DashboardSummary {
+	stats: Stats
+	recentOrders: RecentOrders
+	tablesStatus: TablesStatus
+	topProducts: TopProduct[]
+	period: Period
+}
+
+interface ProductRanking {
+	rank: number
+	id: string
+	name: string
+	category: string
+	price: number
+	quantitySold: number
+	revenue: number
+}
+
+interface Pagination {
+	page: number
+	limit: number
+	total: number
+	totalPages: number
+}
+
+export interface SalesRanking {
+	products: ProductRanking[]
+	pagination: Pagination
+}

--- a/src/app/routes/dashboard/types/mock-dashboard-data-types.ts
+++ b/src/app/routes/dashboard/types/mock-dashboard-data-types.ts
@@ -1,0 +1,4 @@
+export type { Customer } from "@/domains/customers/types/customer-types"
+export type { InventoryItem } from "@/domains/inventory/types/inventory-item-types"
+export type { MenuItem } from "@/shared/types/menu-item-types"
+export type { SalesData } from "./dashboard-analytics-types"

--- a/src/domains/auth/store/auth-store.ts
+++ b/src/domains/auth/store/auth-store.ts
@@ -3,7 +3,7 @@ import { create } from "zustand"
 import { persist } from "zustand/middleware"
 import { dashboardRoutePaths } from "@/app/routes/dashboard/manifest"
 import { authClient } from "@/lib/client"
-import type { User } from "@/types/dashboard"
+import type { User } from "../types/user-types"
 
 interface AuthState {
 	user: User | null

--- a/src/domains/auth/types/user-types.ts
+++ b/src/domains/auth/types/user-types.ts
@@ -1,0 +1,17 @@
+import type { UserRole } from "@/shared/types/user-role-types"
+
+export interface User {
+	id: string
+	email: string
+	name: string
+	avatar?: string
+	role: UserRole
+	createdAt: Date
+}
+
+export interface UserRestaurant {
+	organizationId: string
+	restaurantName: string
+	role: UserRole
+	isOwner: boolean
+}

--- a/src/domains/billing/store/billing-store.ts
+++ b/src/domains/billing/store/billing-store.ts
@@ -1,5 +1,8 @@
 import { create } from "zustand"
-import type { SubscriptionPlan, SubscriptionTier } from "@/types/dashboard"
+import type {
+	SubscriptionPlan,
+	SubscriptionTier,
+} from "@/shared/types/subscription-types"
 
 export const subscriptionPlans: SubscriptionPlan[] = [
 	{

--- a/src/domains/customers/types/customer-types.ts
+++ b/src/domains/customers/types/customer-types.ts
@@ -1,0 +1,13 @@
+export interface Customer {
+	id: string
+	organizationId: string
+	name: string
+	email: string
+	phone: string
+	totalOrders: number
+	totalSpent: number
+	loyaltyPoints: number
+	lastVisit: Date
+	preferences?: string[]
+	avatar?: string
+}

--- a/src/domains/inventory/types/inventory-item-types.ts
+++ b/src/domains/inventory/types/inventory-item-types.ts
@@ -1,0 +1,13 @@
+export interface InventoryItem {
+	id: string
+	organizationId: string
+	name: string
+	quantity: number
+	unit: string
+	minQuantity: number
+	category: string
+	lastRestocked: Date
+	costPerUnit: number
+	location?: string
+	supplier?: string
+}

--- a/src/domains/menu/types/menu-item-types.ts
+++ b/src/domains/menu/types/menu-item-types.ts
@@ -1,0 +1,5 @@
+export type {
+	MenuItem,
+	Recipe,
+	RecipeIngredient,
+} from "@/shared/types/menu-item-types"

--- a/src/domains/menu/types/menu.types.ts
+++ b/src/domains/menu/types/menu.types.ts
@@ -1,1 +1,1 @@
-export type { MenuItem } from "@/types/dashboard"
+export type { MenuItem } from "@/shared/types/menu-item-types"

--- a/src/domains/notifications/store/notification-store.ts
+++ b/src/domains/notifications/store/notification-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand"
-import type { Notification } from "@/types/dashboard"
 import { generateId } from "@/utils/helpers"
+import type { Notification } from "../types/notification-types"
 
 interface NotificationStore {
 	notifications: Notification[]

--- a/src/domains/notifications/types/notification-types.ts
+++ b/src/domains/notifications/types/notification-types.ts
@@ -1,0 +1,9 @@
+export interface Notification {
+	id: string
+	type: "info" | "success" | "warning" | "error"
+	title: string
+	message: string
+	read: boolean
+	createdAt: Date
+	actionUrl?: string
+}

--- a/src/domains/pos/store/cart-store.ts
+++ b/src/domains/pos/store/cart-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand"
 import { persist } from "zustand/middleware"
-import type { Cart, MenuItem } from "@/types/dashboard"
+import type { MenuItem } from "@/shared/types/menu-item-types"
+import type { Cart } from "../types/cart-types"
 
 interface CartState extends Cart {
 	addItem: (menuItem: MenuItem, quantity?: number, notes?: string) => void

--- a/src/domains/pos/types/cart-types.ts
+++ b/src/domains/pos/types/cart-types.ts
@@ -1,0 +1,17 @@
+import type { OrderType } from "@/shared/types/commerce-types"
+import type { MenuItem } from "@/shared/types/menu-item-types"
+
+export interface CartItem {
+	menuItem: MenuItem
+	quantity: number
+	notes?: string
+}
+
+export interface Cart {
+	items: CartItem[]
+	customerId?: string
+	tableId?: string
+	type: OrderType
+	notes?: string
+	splitCount?: number
+}

--- a/src/domains/restaurant/store/restaurant-store.ts
+++ b/src/domains/restaurant/store/restaurant-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand"
-import type { Restaurant, SubscriptionTier } from "@/types/dashboard"
+import type { SubscriptionTier } from "@/shared/types/subscription-types"
+import type { Restaurant } from "../types/restaurant-types"
 
 interface RestaurantState {
 	activeRestaurant: Restaurant | null

--- a/src/domains/restaurant/types/restaurant-types.ts
+++ b/src/domains/restaurant/types/restaurant-types.ts
@@ -1,0 +1,27 @@
+import type { PaymentMethod } from "@/shared/types/commerce-types"
+import type { Subscription } from "@/shared/types/subscription-types"
+
+export interface RestaurantSettings {
+	requireCashierApproval: boolean
+	defaultPaymentMethods: PaymentMethod[]
+	taxRate: number
+	invoicePrefix: string
+	theme: "light" | "dark" | "system"
+	timezone: string
+}
+
+export interface Restaurant {
+	id: string
+	ownerId: string
+	name: string
+	slug: string
+	logo?: string
+	address: string
+	phone: string
+	timezone: string
+	currency: string
+	settings: RestaurantSettings
+	subscription: Subscription
+	createdAt: Date
+	updatedAt: Date
+}

--- a/src/services/dashboard-service.ts
+++ b/src/services/dashboard-service.ts
@@ -2,7 +2,8 @@ import type {
 	DashboardRevenue,
 	DashboardSummary,
 	SalesRanking,
-} from "@/types/dashboard"
+} from "@/app/routes/dashboard/types/dashboard-analytics-types"
+
 import { apiFetch } from "@/utils/fetch"
 
 export function getDashboardSummary(

--- a/src/shared/types/commerce-types.ts
+++ b/src/shared/types/commerce-types.ts
@@ -1,0 +1,3 @@
+export type PaymentMethod = "cash" | "credit" | "debit" | "pix" | "meal_voucher"
+
+export type OrderType = "dine_in" | "takeaway" | "delivery"

--- a/src/shared/types/menu-item-types.ts
+++ b/src/shared/types/menu-item-types.ts
@@ -1,0 +1,29 @@
+export interface RecipeIngredient {
+	inventoryItemId: string
+	name: string
+	quantity: number
+	unit: string
+}
+
+export interface Recipe {
+	id: string
+	menuItemId: string
+	ingredients: RecipeIngredient[]
+	yield: number
+	instructions?: string
+}
+
+export interface MenuItem {
+	id: string
+	organizationId: string
+	name: string
+	description: string
+	price: number | string
+	category: string
+	image: string
+	available: boolean
+	preparationTime: number
+	calories?: number
+	allergens?: string[]
+	recipe?: Recipe
+}

--- a/src/shared/types/subscription-types.ts
+++ b/src/shared/types/subscription-types.ts
@@ -1,0 +1,28 @@
+export type SubscriptionTier = "free" | "pro" | "enterprise"
+
+export type SubscriptionStatus = "active" | "cancelled" | "expired" | "trial"
+
+export interface SubscriptionPlan {
+	id: SubscriptionTier
+	name: string
+	price: number
+	interval: "month" | "year"
+	features: string[]
+	limits: {
+		ordersPerMonth: number
+		products: number
+		staff: number
+		locations: number
+		analytics: "basic" | "advanced" | "full"
+	}
+}
+
+export interface Subscription {
+	id: string
+	organizationId: string
+	plan: SubscriptionTier
+	status: SubscriptionStatus
+	currentPeriodStart: Date
+	currentPeriodEnd: Date
+	cancelAtPeriodEnd: boolean
+}

--- a/src/shared/types/user-role-types.ts
+++ b/src/shared/types/user-role-types.ts
@@ -1,0 +1,1 @@
+export type UserRole = "owner" | "manager" | "cashier" | "kitchen" | "waiter"

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,209 +1,39 @@
-export type OrderStatus =
-	| "pending"
-	| "confirmed"
-	| "preparing"
-	| "ready"
-	| "delivered"
-	| "cancelled"
-	| "rejected"
-export type PaymentMethod = "cash" | "credit" | "debit" | "pix" | "meal_voucher"
-export type OrderType = "dine_in" | "takeaway" | "delivery"
-export type TableStatus = "available" | "occupied" | "reserved" | "cleaning"
-export type UserRole = "owner" | "manager" | "cashier" | "kitchen" | "waiter"
-
-export type SubscriptionTier = "free" | "pro" | "enterprise"
-export type SubscriptionStatus = "active" | "cancelled" | "expired" | "trial"
-
-export interface SubscriptionPlan {
-	id: SubscriptionTier
-	name: string
-	price: number
-	interval: "month" | "year"
-	features: string[]
-	limits: {
-		ordersPerMonth: number
-		products: number
-		staff: number
-		locations: number
-		analytics: "basic" | "advanced" | "full"
-	}
-}
-
-export interface Subscription {
-	id: string
-	organizationId: string
-	plan: SubscriptionTier
-	status: SubscriptionStatus
-	currentPeriodStart: Date
-	currentPeriodEnd: Date
-	cancelAtPeriodEnd: boolean
-}
-
-export interface Restaurant {
-	id: string
-	ownerId: string
-	name: string
-	slug: string
-	logo?: string
-	address: string
-	phone: string
-	timezone: string
-	currency: string
-	settings: RestaurantSettings
-	subscription: Subscription
-	createdAt: Date
-	updatedAt: Date
-}
-
-export interface RestaurantSettings {
-	requireCashierApproval: boolean
-	defaultPaymentMethods: PaymentMethod[]
-	taxRate: number
-	invoicePrefix: string
-	theme: "light" | "dark" | "system"
-	timezone: string
-}
-
-export interface User {
-	id: string
-	email: string
-	name: string
-	avatar?: string
-	role: UserRole
-
-	// restaurants: UserRestaurant[]
-	createdAt: Date
-}
-
-export interface UserRestaurant {
-	organizationId: string
-	restaurantName: string
-	role: UserRole
-	isOwner: boolean
-}
-
-export interface MenuItem {
-	id: string
-	organizationId: string
-	name: string
-	description: string
-	price: number | string
-	category: string
-	image: string
-	available: boolean
-	preparationTime: number
-	calories?: number
-	allergens?: string[]
-	recipe?: Recipe
-}
-
-export interface RecipeIngredient {
-	inventoryItemId: string
-	name: string
-	quantity: number
-	unit: string
-}
-
-export interface Recipe {
-	id: string
-	menuItemId: string
-	ingredients: RecipeIngredient[]
-	yield: number
-	instructions?: string
-}
-
-export interface OrderItem {
-	id: string
-	menuItemId: string
-	name: string
-	quantity: number
-	price: number
-	notes?: string
-	status: OrderStatus
-	recipeUsed?: boolean
-}
-
-export interface Order {
-	id: string
-	organizationId: string
-	tableId?: string
-	customerId?: string
-	staffId?: string
-	orderItems: OrderItem[]
-	status: OrderStatus
-	approvalStatus?: "pending" | "approved" | "rejected"
-	approvedBy?: string
-	approvalNotes?: string
-	type: OrderType
-	subtotal: number
-	tax: number
-	discount: number
-	total: number
-	paymentMethod?: PaymentMethod
-	paymentStatus: "pending" | "paid" | "refunded"
-	splitBill?: SplitBill[]
-	createdAt: Date
-	updatedAt: Date
-	customerName?: string
-	notes?: string
-	orderNumber: number
-	itemsCount?: number
-}
-
-export interface SplitBill {
-	id: string
-	amount: number
-	paymentMethod?: PaymentMethod
-	paid: boolean
-}
-
-export interface Table {
-	id: string
-	organizationId: string
-	number: number
-	capacity: number
-	status: TableStatus
-	currentOrderId?: string
-	section: string
-}
-
-export interface Customer {
-	id: string
-	organizationId: string
-	name: string
-	email: string
-	phone: string
-	totalOrders: number
-	totalSpent: number
-	loyaltyPoints: number
-	lastVisit: Date
-	preferences?: string[]
-	avatar?: string
-}
-
-export interface Staff {
-	id: string
-	organizationId: string
-	name: string
-	role: UserRole
-	avatar: string
-	active: boolean
-	pin?: string
-}
-
-export interface InventoryItem {
-	id: string
-	organizationId: string
-	name: string
-	quantity: number
-	unit: string
-	minQuantity: number
-	category: string
-	lastRestocked: Date
-	costPerUnit: number
-	location?: string
-	supplier?: string
-}
+export type {
+	DashboardRevenue,
+	DashboardSummary,
+	RevenueChartPoint as Daum,
+	SalesData,
+	SalesRanking,
+} from "@/app/routes/dashboard/types/dashboard-analytics-types"
+export type { User, UserRestaurant } from "@/domains/auth/types/user-types"
+export type { Customer } from "@/domains/customers/types/customer-types"
+export type { InventoryItem } from "@/domains/inventory/types/inventory-item-types"
+export type { Notification } from "@/domains/notifications/types/notification-types"
+export type {
+	Order,
+	OrderItem,
+	OrderStatus,
+	SplitBill,
+} from "@/domains/orders/types/order.types"
+export type { Cart, CartItem } from "@/domains/pos/types/cart-types"
+export type {
+	Restaurant,
+	RestaurantSettings,
+} from "@/domains/restaurant/types/restaurant-types"
+export type { Table, TableStatus } from "@/domains/tables/types/table.types"
+export type { OrderType, PaymentMethod } from "@/shared/types/commerce-types"
+export type {
+	MenuItem,
+	Recipe,
+	RecipeIngredient,
+} from "@/shared/types/menu-item-types"
+export type {
+	Subscription,
+	SubscriptionPlan,
+	SubscriptionStatus,
+	SubscriptionTier,
+} from "@/shared/types/subscription-types"
+export type { UserRole } from "@/shared/types/user-role-types"
 
 export interface InventoryTransaction {
 	id: string
@@ -216,23 +46,6 @@ export interface InventoryTransaction {
 	createdAt: Date
 }
 
-export interface Notification {
-	id: string
-	type: "info" | "success" | "warning" | "error"
-	title: string
-	message: string
-	read: boolean
-	createdAt: Date
-	actionUrl?: string
-}
-
-export interface SalesData {
-	date: string
-	revenue: number
-	orders: number
-	expenses: number
-}
-
 export interface DashboardMetrics {
 	revenue: number
 	orders: number
@@ -241,114 +54,12 @@ export interface DashboardMetrics {
 	lowStockItems: number
 }
 
-export interface CartItem {
-	menuItem: MenuItem
-	quantity: number
-	notes?: string
-}
-
-export interface Cart {
-	items: CartItem[]
-	customerId?: string
-	tableId?: string
-	type: OrderType
-	notes?: string
-	splitCount?: number
-}
-
-export interface DashboardRevenue {
-	data: Daum[]
-	summary: RevenueSummary
-}
-
-export interface DashboardSummary {
-	stats: Stats
-	recentOrders: RecentOrders
-	tablesStatus: TablesStatus
-	topProducts: TopProduct[]
-	period: Period
-}
-
-export interface SalesRanking {
-	products: ProductRanking[]
-	pagination: Pagination
-}
-
-interface ProductRanking {
-	rank: number
+export interface Staff {
 	id: string
+	organizationId: string
 	name: string
-	category: string
-	price: number
-	quantitySold: number
-	revenue: number
-}
-
-interface Pagination {
-	page: number
-	limit: number
-	total: number
-	totalPages: number
-}
-
-export interface Daum {
-	date: string
-	revenue: number
-	orders: number
-}
-
-interface RevenueSummary {
-	totalRevenue: number
-	percentageChange: number
-}
-
-interface StatsRoot {
-	current: number
-	previous: number
-	percentageChange: number
-}
-
-interface Tables {
-	occupied: number
-	total: number
-	percentageChange: number
-}
-
-interface Stats {
-	revenue: StatsRoot
-	orders: StatsRoot
-	tables: Tables
-}
-
-interface RecentOrders {
-	total: number
-	orders: Order[]
-}
-
-interface TablesStatus {
-	summary: Summary
-	tables: Table[]
-}
-
-interface Summary {
-	available: number
-	occupied: number
-	reserved: number
-	cleaning: number
-	total: number
-}
-
-interface TopProduct {
-	rank: number
-	id: string
-	name: string
-	category: string
-	price: number
-	quantitySold: number
-}
-
-interface Period {
-	days: number
-	startDate: string
-	endDate: string
+	role: import("@/shared/types/user-role-types").UserRole
+	avatar: string
+	active: boolean
+	pin?: string
 }


### PR DESCRIPTION
## Contexto
`src/types/dashboard.ts` concentrava tipos de varios contextos e aumentava o acoplamento transversal. Este PR inicia a decomposicao por dominio e deixa um adapter de transicao para manter compatibilidade de imports legados.

## O que mudou
- Cria tipos por dominio para auth, restaurant, notifications e pos.
- Cria contratos cross-domain em `src/shared/types` para `payment/order`, `subscription`, `user role` e `menu item`.
- Cria tipos de analytics do dashboard em `src/app/routes/dashboard/types/dashboard-analytics-types.ts`.
- Atualiza imports dos consumidores principais para usar tipos de dominio/shared, reduzindo dependencia direta de `@/types/dashboard`.
- Mantem `src/types/dashboard.ts` como camada de compatibilidade (adapter), reexportando os novos tipos.

## Como validar
1. `pnpm build`
2. `pnpm check`
3. Validacao funcional/manual:
   - Abrir dashboard (home, POS, notificacoes) e confirmar funcionamento normal.
   - Verificar que os modulos compilam sem depender diretamente do monolito de tipos para os casos migrados.

## Checklist geral
- [x] Texto user-facing em pt-BR.
- [x] Sem codigo morto e sem import nao utilizado.
- [x] Sem alteracao fora do escopo.

## Checklist de arquitetura
- [x] Respeita fronteiras `app/domains/shared`.
- [x] Sem import cruzado direto entre dominios.
- [x] Naming e paths seguem `docs/naming.md` e `docs/architecture.md`.
- [x] Tipos cross-domain estao em `shared/types`.
- [ ] Quando houve migracao, `docs/architecture.md` foi atualizado.

Closes #41