### PR TITLE
refactor: iniciar base de dados por domínio para remoção de mocks (#87)

### DIFF
--- a/docs/roadmap-remocao-mocks.md
+++ b/docs/roadmap-remocao-mocks.md
@@ -1,0 +1,79 @@
+# Roadmap de Remocao de Mocks e Alinhamento da Landing
+
+## Objetivo
+
+Remover dados mockados do produto, conectar os modulos principais ao backend real
+e alinhar a comunicacao da landing page com o que esta disponivel no sistema.
+
+## Principios
+
+- Priorizar fluxo operacional critico (pedidos, estoque, clientes, vendas).
+- Migrar por dominios, com entregas pequenas e rollback por modulo.
+- Evitar fallback silencioso para mock em qualquer tela.
+- Manter rastreabilidade com issues no projeto `Menu Frontend Refactor`.
+
+## Sprint 1 (P0) - Base de dados reais e dominios criticos
+
+- [#87](https://github.com/lopesboa/menu/issues/87) `[front]` Padronizar infraestrutura de dados por dominio.
+- [#74](https://github.com/lopesboa/menu/issues/74) `[front+back]` Migrar Clientes para API real.
+- [#75](https://github.com/lopesboa/menu/issues/75) `[front+back]` Migrar Inventario para API real e low-stock.
+- [#89](https://github.com/lopesboa/menu/issues/89) `[front+back]` Definir DoD de modulo sem mock.
+
+### Saida esperada
+
+- Clientes e Inventario sem dependencia de `mock-data`.
+- Estado de loading/vazio/erro/retry padronizado nos modulos migrados.
+- Criterio de aceite formal para novas migracoes sem mock.
+
+## Sprint 2 (P0) - Vendas, relatorios e cardapio
+
+- [#76](https://github.com/lopesboa/menu/issues/76) `[front+back]` Migrar Sales para dados reais.
+- [#77](https://github.com/lopesboa/menu/issues/77) `[front+back]` Migrar Reports para APIs reais.
+- [#79](https://github.com/lopesboa/menu/issues/79) `[front+back]` Migrar Menu Builder para CRUD real.
+- [#80](https://github.com/lopesboa/menu/issues/80) `[front+back]` Remover `mockRestaurants` e carregar restaurante real.
+
+### Saida esperada
+
+- KPIs sem dados aleatorios ou hardcoded.
+- Fluxo de cardapio com CRUD real por organizacao.
+- Contexto do restaurante ativo vindo de fonte real.
+
+## Sprint 3 (P0/P1) - Operacao ponta a ponta
+
+- [#78](https://github.com/lopesboa/menu/issues/78) `[front+back]` Finalizar pedido no PDV com persistencia real.
+- [#86](https://github.com/lopesboa/menu/issues/86) `[front+back]` Remover blocos estaticos da tela de Delivery.
+- [#88](https://github.com/lopesboa/menu/issues/88) `[front]` Decomissionar `mock-data.ts`.
+
+### Saida esperada
+
+- Pedido criado no PDV refletindo em operacao real.
+- Delivery sem indicadores cenograficos para uso diario.
+- Eliminacao total do arquivo central de mocks.
+
+## Sprint 4 (P1) - Alinhamento comercial e features habilitadoras
+
+- [#84](https://github.com/lopesboa/menu/issues/84) `[front]` Alinhar landing com funcionalidades disponiveis.
+- [#85](https://github.com/lopesboa/menu/issues/85) `[front]` Destacar modulos operacionais ja existentes.
+- [#81](https://github.com/lopesboa/menu/issues/81) `[front+back]` Implementar modulo de API Keys.
+- [#82](https://github.com/lopesboa/menu/issues/82) `[front+back]` Criar dominio de Staff no frontend.
+- [#83](https://github.com/lopesboa/menu/issues/83) `[front+back]` Substituir billing mock por fonte real (ou escopo temporario explicito).
+
+### Saida esperada
+
+- Landing sem promessas acima do que o produto entrega.
+- Melhor comunicacao de valor de funcionalidades reais.
+- Evolucao de capacidades enterprise e de administracao.
+
+## Dependencias e riscos
+
+- Dependencia de contratos de backend para payloads finais de pedidos, vendas e cobranca.
+- Risco de divergencia de metricas durante migracao de relatorios.
+- Risco de regressao de UX em telas com alto acoplamento legado.
+- Mitigacao: rollout por modulo, observabilidade e rollback localizado.
+
+## Criterio de conclusao do roadmap
+
+- Nenhuma tela operacional depende de dados mockados.
+- Nenhuma metrica de negocio depende de `Math.random` ou hardcode.
+- Landing reflete com precisao o estado real das features.
+- Issues P0 concluídas e P1 com plano de execucao ativo no projeto.

--- a/src/app/routes/dashboard/data/recipes.ts
+++ b/src/app/routes/dashboard/data/recipes.ts
@@ -1,0 +1,193 @@
+import type { Recipe, RecipeIngredient } from "@/types/dashboard"
+
+export const recipes: Record<string, Recipe> = {
+	"1": {
+		id: "recipe-1",
+		menuItemId: "1",
+		yield: 1,
+		ingredients: [
+			{
+				inventoryItemId: "inv12",
+				name: "Pão Italiano",
+				quantity: 1,
+				unit: "unidades",
+			},
+			{ inventoryItemId: "inv13", name: "Tomate", quantity: 100, unit: "g" },
+			{ inventoryItemId: "inv17", name: "Manjericão", quantity: 10, unit: "g" },
+			{
+				inventoryItemId: "inv17",
+				name: "Azeite de Oliveira",
+				quantity: 20,
+				unit: "ml",
+			},
+		],
+		instructions:
+			"Torrar o pão, cortar tomates, adicionar manjericão e azeite.",
+	},
+	"2": {
+		id: "recipe-2",
+		menuItemId: "2",
+		yield: 1,
+		ingredients: [
+			{
+				inventoryItemId: "inv1",
+				name: "Filé Mignon",
+				quantity: 150,
+				unit: "g",
+			},
+			{ inventoryItemId: "inv6", name: "Parmesian", quantity: 30, unit: "g" },
+			{ inventoryItemId: "inv18", name: "Alcaparras", quantity: 20, unit: "g" },
+		],
+		instructions: "Fatiar filé bem fino, adicionar alcaparras e parmesan.",
+	},
+	"6": {
+		id: "recipe-6",
+		menuItemId: "6",
+		yield: 1,
+		ingredients: [
+			{
+				inventoryItemId: "inv1",
+				name: "Filé Mignon",
+				quantity: 200,
+				unit: "g",
+			},
+			{
+				inventoryItemId: "inv9",
+				name: "Arroz Arbório",
+				quantity: 150,
+				unit: "g",
+			},
+			{ inventoryItemId: "inv10", name: "Batata", quantity: 200, unit: "g" },
+			{
+				inventoryItemId: "inv14",
+				name: "Alface Romana",
+				quantity: 50,
+				unit: "g",
+			},
+		],
+		instructions: "Grelhar filé no ponto deseado, servir com arroz e batata.",
+	},
+	"7": {
+		id: "recipe-7",
+		menuItemId: "7",
+		yield: 1,
+		ingredients: [
+			{ inventoryItemId: "inv2", name: "Frango", quantity: 200, unit: "g" },
+			{ inventoryItemId: "inv5", name: "Mussarela", quantity: 80, unit: "g" },
+			{
+				inventoryItemId: "inv11",
+				name: "Massa para Pizza",
+				quantity: 1,
+				unit: "unidades",
+			},
+			{
+				inventoryItemId: "inv18",
+				name: "Molho de Tomate",
+				quantity: 100,
+				unit: "ml",
+			},
+		],
+		instructions: "Empanar frango, fritar, cobrir com molho e mussarela.",
+	},
+	"15": {
+		id: "recipe-15",
+		menuItemId: "15",
+		yield: 1,
+		ingredients: [
+			{
+				inventoryItemId: "inv19",
+				name: "Pão de Hambúrguer",
+				quantity: 1,
+				unit: "unidades",
+			},
+			{
+				inventoryItemId: "inv1",
+				name: "Carne Moída",
+				quantity: 180,
+				unit: "g",
+			},
+			{ inventoryItemId: "inv13", name: "Alface", quantity: 30, unit: "g" },
+			{ inventoryItemId: "inv15", name: "Tomate", quantity: 50, unit: "g" },
+		],
+		instructions: "Grear hambúrguer, montar no pão com vegetais.",
+	},
+	"32": {
+		id: "recipe-32",
+		menuItemId: "32",
+		yield: 1,
+		ingredients: [
+			{ inventoryItemId: "inv3", name: "Mojarra", quantity: 400, unit: "g" },
+			{ inventoryItemId: "inv9", name: "Arroz", quantity: 200, unit: "g" },
+			{ inventoryItemId: "inv10", name: "Farofa", quantity: 100, unit: "g" },
+			{
+				inventoryItemId: "inv14",
+				name: "Limão",
+				quantity: 1,
+				unit: "unidades",
+			},
+		],
+		instructions: "Fritar mojarra, servir com arroz, farofa e pirão.",
+	},
+	"46": {
+		id: "recipe-46",
+		menuItemId: "46",
+		yield: 1,
+		ingredients: [
+			{ inventoryItemId: "inv1", name: "Maminha", quantity: 300, unit: "g" },
+			{ inventoryItemId: "inv9", name: "Arroz", quantity: 150, unit: "g" },
+			{ inventoryItemId: "inv10", name: "Farofa", quantity: 80, unit: "g" },
+			{ inventoryItemId: "inv14", name: "Alface", quantity: 50, unit: "g" },
+		],
+		instructions: "Grelhar maminha, servir com arroz e farofa.",
+	},
+	"47": {
+		id: "recipe-47",
+		menuItemId: "47",
+		yield: 1,
+		ingredients: [
+			{ inventoryItemId: "inv1", name: "Picanha", quantity: 350, unit: "g" },
+			{ inventoryItemId: "inv9", name: "Arroz", quantity: 150, unit: "g" },
+			{ inventoryItemId: "inv16", name: "Batata", quantity: 150, unit: "g" },
+		],
+		instructions: "Grelhar picanha no ponto solicitado.",
+	},
+}
+
+export function getRecipeForItem(menuItemId: string): Recipe | undefined {
+	return recipes[menuItemId]
+}
+
+export function getIngredientUsage(
+	menuItemId: string,
+	quantity = 1
+): RecipeIngredient[] {
+	const recipe = recipes[menuItemId]
+	if (!recipe) {
+		return []
+	}
+	return recipe.ingredients.map((ing) => ({
+		...ing,
+		quantity: ing.quantity * quantity,
+	}))
+}
+
+export function checkIngredientAvailability(
+	menuItemId: string,
+	quantity: number,
+	inventory: Record<string, { quantity: number; unit: string }>
+): { available: boolean; missing: string[] } {
+	const ingredients = getIngredientUsage(menuItemId, quantity)
+	const missing: string[] = []
+
+	for (const ing of ingredients) {
+		const invItem = inventory[ing.inventoryItemId]
+		if (!invItem || invItem.quantity < ing.quantity) {
+			missing.push(ing.name)
+		}
+	}
+
+	return {
+		available: missing.length === 0,
+		missing,
+	}
+}


### PR DESCRIPTION
## Contexto

Esta entrega inicia a base da task #87 para reduzir regressões na migração de mocks para API real, consolidando um roadmap de execução por sprint e estruturando dados de receitas em arquivo dedicado.

## O que mudou

- Adicionado `docs/roadmap-remocao-mocks.md` com plano por sprints, dependências, riscos e critério de conclusão.
- Adicionado `src/app/routes/dashboard/data/recipes.ts` com catálogo de receitas e utilitários de uso/disponibilidade de ingredientes.
- Escopo limitado à fundação de dados e documentação para suportar a padronização da infraestrutura por domínio.
- Closes #87

## Como validar

1. `pnpm build`
2. `pnpm check`
3. Validacao funcional/manual (descrever)
   - Navegar nos fluxos do dashboard que dependem de receitas e confirmar que não há regressões de leitura/cálculo de ingredientes.

## Checklist geral

- [x] Texto user-facing em pt-BR.
- [x] Sem codigo morto e sem import nao utilizado.
- [x] Sem alteracao fora do escopo.

## Checklist de arquitetura

- [ ] Respeita fronteiras `app/domains/shared`.
- [ ] Sem import cruzado direto entre dominios.
- [ ] Naming e paths seguem `docs/naming.md` e `docs/architecture.md`.
- [ ] Tipos cross-domain estao em `shared/types`.
- [ ] Quando houve migracao, `docs/architecture.md` foi atualizado.