### PR TITLE
refactor: ajustar inventário ao contrato paginado e filtros da API (#75)

### DIFF
--- a/src/app/routes/dashboard/pages/inventory.tsx
+++ b/src/app/routes/dashboard/pages/inventory.tsx
@@ -8,7 +8,7 @@ import {
 	Search,
 	Trash2,
 } from "lucide-react"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { Modal } from "@/components/ui/modal"
 import {
@@ -22,10 +22,10 @@ import { cn } from "@/utils/misc"
 
 const PAGE_SIZE = 20
 
+//TODO: rever essa quantitdade de estados, seria uma boa zustand/useReducer aqui
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: página reúne estados de listagem, alerta e paginação do inventário.
 export function InventoryPage() {
 	const [searchQuery, setSearchQuery] = useState("")
-	const [debouncedSearch, setDebouncedSearch] = useState("")
 	const [selectedCategory, setSelectedCategory] = useState("all")
 	const [offset, setOffset] = useState(0)
 	const [isModalOpen, setIsModalOpen] = useState(false)
@@ -41,7 +41,7 @@ export function InventoryPage() {
 		organizationId,
 		limit: PAGE_SIZE,
 		offset,
-		search: debouncedSearch || undefined,
+		search: searchQuery.trim() || undefined,
 		category: selectedCategory !== "all" ? selectedCategory : undefined,
 	})
 	const {
@@ -63,68 +63,36 @@ export function InventoryPage() {
 	const currentPage =
 		Math.floor((inventoryPagination?.offset ?? offset) / PAGE_SIZE) + 1
 	const totalPages = Math.max(1, Math.ceil(totalInventoryItems / PAGE_SIZE))
-	const hasNotifiedInventoryError = useRef(false)
-	const hasNotifiedLowStockError = useRef(false)
 
 	useEffect(() => {
-		const timeout = window.setTimeout(() => {
-			setDebouncedSearch(searchQuery.trim())
-			setOffset(0)
-		}, 350)
-
-		return () => window.clearTimeout(timeout)
-	}, [searchQuery])
-
-	useEffect(() => {
-		if (
-			!(isInventoryError && inventoryError) ||
-			hasNotifiedInventoryError.current
-		) {
-			if (!isInventoryError) {
-				hasNotifiedInventoryError.current = false
-			}
-			return
+		if (isInventoryError && inventoryError) {
+			toast.error("Falha ao carregar o inventário")
+			sentryCaptureException(inventoryError, {
+				context: "inventory_list_fetch",
+				organizationId,
+			})
 		}
-
-		hasNotifiedInventoryError.current = true
-		toast.error("Falha ao carregar o inventário")
-		sentryCaptureException(inventoryError, {
-			context: "inventory_list_fetch",
-			organizationId,
-		})
 	}, [isInventoryError, inventoryError, organizationId])
 
 	useEffect(() => {
-		if (
-			!(isLowStockError && lowStockError) ||
-			hasNotifiedLowStockError.current
-		) {
-			if (!isLowStockError) {
-				hasNotifiedLowStockError.current = false
-			}
-			return
+		if (isLowStockError && lowStockError) {
+			toast.error("Falha ao carregar os alertas de estoque")
+			sentryCaptureException(lowStockError, {
+				context: "inventory_low_stock_fetch",
+				organizationId,
+			})
 		}
-
-		hasNotifiedLowStockError.current = true
-		toast.error("Falha ao carregar os alertas de estoque")
-		sentryCaptureException(lowStockError, {
-			context: "inventory_low_stock_fetch",
-			organizationId,
-		})
 	}, [isLowStockError, lowStockError, organizationId])
 
-	const categories = useMemo(
-		() => ["all", ...new Set(inventoryItems.map((item) => item.category))],
-		[inventoryItems]
-	)
+	//TODO: categories e totalValue precisam vir do backend
+	const categories = [
+		"all",
+		...new Set(inventoryItems.map((item) => item.category)),
+	]
 
-	const totalValue = useMemo(
-		() =>
-			inventoryItems.reduce(
-				(sum, item) => sum + item.quantity * item.costPerUnit,
-				0
-			),
-		[inventoryItems]
+	const totalValue = inventoryItems.reduce(
+		(sum, item) => sum + item.quantity * item.costPerUnit,
+		0
 	)
 
 	return (
@@ -375,7 +343,7 @@ export function InventoryPage() {
 											className="px-6 py-8 text-center text-surface-600"
 											colSpan={7}
 										>
-											{debouncedSearch
+											{searchQuery
 												? "Nenhum item encontrado para a busca."
 												: "Nenhum item de inventário encontrado."}
 										</td>

--- a/src/app/routes/dashboard/pages/inventory.tsx
+++ b/src/app/routes/dashboard/pages/inventory.tsx
@@ -20,27 +20,60 @@ import { sentryCaptureException } from "@/lib/sentry"
 import { formatCurrency } from "@/utils/helpers"
 import { cn } from "@/utils/misc"
 
+const PAGE_SIZE = 20
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: página reúne estados de listagem, alerta e paginação do inventário.
 export function InventoryPage() {
 	const [searchQuery, setSearchQuery] = useState("")
+	const [debouncedSearch, setDebouncedSearch] = useState("")
 	const [selectedCategory, setSelectedCategory] = useState("all")
+	const [offset, setOffset] = useState(0)
 	const [isModalOpen, setIsModalOpen] = useState(false)
 	const { organizationId } = useOrganizationCheck()
 	const {
-		data: inventoryItems = [],
+		data: inventoryData,
 		error: inventoryError,
 		isError: isInventoryError,
 		isLoading: isInventoryLoading,
 		refetch: refetchInventory,
-	} = useInventory(organizationId)
+		isFetching: isInventoryFetching,
+	} = useInventory({
+		organizationId,
+		limit: PAGE_SIZE,
+		offset,
+		search: debouncedSearch || undefined,
+		category: selectedCategory !== "all" ? selectedCategory : undefined,
+	})
 	const {
-		data: lowStockItems = [],
+		data: lowStockData,
 		error: lowStockError,
 		isError: isLowStockError,
 		isLoading: isLowStockLoading,
 		refetch: refetchLowStock,
-	} = useInventoryLowStock(organizationId)
+	} = useInventoryLowStock({
+		organizationId,
+		limit: 1,
+		offset: 0,
+	})
+	const inventoryItems = inventoryData?.items ?? []
+	const inventoryPagination = inventoryData?.pagination
+	const lowStockTotal = lowStockData?.pagination.total ?? 0
+	const totalInventoryItems =
+		inventoryPagination?.total ?? inventoryItems.length
+	const currentPage =
+		Math.floor((inventoryPagination?.offset ?? offset) / PAGE_SIZE) + 1
+	const totalPages = Math.max(1, Math.ceil(totalInventoryItems / PAGE_SIZE))
 	const hasNotifiedInventoryError = useRef(false)
 	const hasNotifiedLowStockError = useRef(false)
+
+	useEffect(() => {
+		const timeout = window.setTimeout(() => {
+			setDebouncedSearch(searchQuery.trim())
+			setOffset(0)
+		}, 350)
+
+		return () => window.clearTimeout(timeout)
+	}, [searchQuery])
 
 	useEffect(() => {
 		if (
@@ -84,22 +117,6 @@ export function InventoryPage() {
 		() => ["all", ...new Set(inventoryItems.map((item) => item.category))],
 		[inventoryItems]
 	)
-
-	const filteredItems = useMemo(() => {
-		return inventoryItems.filter((item) => {
-			if (selectedCategory !== "all" && item.category !== selectedCategory) {
-				return false
-			}
-			if (searchQuery) {
-				const query = searchQuery.toLowerCase()
-				return (
-					item.name.toLowerCase().includes(query) ||
-					item.category.toLowerCase().includes(query)
-				)
-			}
-			return true
-		})
-	}, [inventoryItems, selectedCategory, searchQuery])
 
 	const totalValue = useMemo(
 		() =>
@@ -165,7 +182,7 @@ export function InventoryPage() {
 				</motion.div>
 			)}
 
-			{!(isLowStockLoading || isLowStockError) && lowStockItems.length > 0 && (
+			{!(isLowStockLoading || isLowStockError) && lowStockTotal > 0 && (
 				<motion.div
 					animate={{ opacity: 1, y: 0 }}
 					className="flex items-center gap-4 rounded-2xl border border-red-200 bg-red-50 p-4"
@@ -177,7 +194,7 @@ export function InventoryPage() {
 							Atenção! Itens com estoque baixo
 						</p>
 						<p className="text-red-700 text-sm">
-							{lowStockItems.length} itens precisam ser repostos em breve
+							{lowStockTotal} itens precisam ser repostos em breve
 						</p>
 					</div>
 					<button
@@ -204,7 +221,7 @@ export function InventoryPage() {
 						<div>
 							<p className="text-sm text-surface-500">Total de Itens</p>
 							<p className="font-bold text-2xl text-surface-900">
-								{inventoryItems.length}
+								{totalInventoryItems}
 							</p>
 						</div>
 					</div>
@@ -230,7 +247,7 @@ export function InventoryPage() {
 						<div>
 							<p className="text-sm text-surface-500">Estoque Baixo</p>
 							<p className="font-bold text-2xl text-surface-900">
-								{lowStockItems.length}
+								{lowStockTotal}
 							</p>
 						</div>
 					</div>
@@ -254,6 +271,11 @@ export function InventoryPage() {
 							value={searchQuery}
 						/>
 					</div>
+					{isInventoryFetching && !isInventoryLoading && (
+						<p className="text-surface-500 text-xs">
+							Atualizando inventário...
+						</p>
+					)}
 					<div className="flex gap-2">
 						{categories.map((category) => (
 							<button
@@ -264,7 +286,10 @@ export function InventoryPage() {
 										: "text-surface-600 hover:bg-surface-50"
 								)}
 								key={category}
-								onClick={() => setSelectedCategory(category)}
+								onClick={() => {
+									setSelectedCategory(category)
+									setOffset(0)
+								}}
 								type="button"
 							>
 								{category === "all" ? "Todos" : category}
@@ -344,13 +369,13 @@ export function InventoryPage() {
 
 							{organizationId &&
 								!(isInventoryLoading || isInventoryError) &&
-								filteredItems.length === 0 && (
+								inventoryItems.length === 0 && (
 									<tr>
 										<td
 											className="px-6 py-8 text-center text-surface-600"
 											colSpan={7}
 										>
-											{searchQuery
+											{debouncedSearch
 												? "Nenhum item encontrado para a busca."
 												: "Nenhum item de inventário encontrado."}
 										</td>
@@ -358,7 +383,7 @@ export function InventoryPage() {
 								)}
 
 							{!(isInventoryLoading || isInventoryError) &&
-								filteredItems.map((item, index) => (
+								inventoryItems.map((item, index) => (
 									<motion.tr
 										animate={{ opacity: 1, y: 0 }}
 										className="border-surface-50 border-b hover:bg-surface-50"
@@ -437,6 +462,37 @@ export function InventoryPage() {
 								))}
 						</tbody>
 					</table>
+					{organizationId && !isInventoryLoading && !isInventoryError && (
+						<div className="flex items-center justify-between border-surface-100 border-t px-4 py-3 text-sm">
+							<p className="text-surface-500">
+								Página {currentPage} de {totalPages}
+							</p>
+							<div className="flex items-center gap-2">
+								<button
+									className="btn-secondary"
+									disabled={offset <= 0}
+									onClick={() =>
+										setOffset((currentOffset) =>
+											Math.max(0, currentOffset - PAGE_SIZE)
+										)
+									}
+									type="button"
+								>
+									Anterior
+								</button>
+								<button
+									className="btn-secondary"
+									disabled={offset + PAGE_SIZE >= totalInventoryItems}
+									onClick={() =>
+										setOffset((currentOffset) => currentOffset + PAGE_SIZE)
+									}
+									type="button"
+								>
+									Próxima
+								</button>
+							</div>
+						</div>
+					)}
 				</div>
 			</motion.div>
 

--- a/src/domains/inventory/api/inventory-api.ts
+++ b/src/domains/inventory/api/inventory-api.ts
@@ -4,34 +4,62 @@ import type {
 	InventoryItemApi,
 } from "../types/inventory-item-types"
 
-interface InventoryApiEnvelope {
-	inventory?: InventoryItemApi[]
-	items?: InventoryItemApi[]
-	data?: InventoryItemApi[]
+export interface InventoryPagination {
+	limit: number
+	offset: number
+	total: number
 }
 
-type InventoryApiResponse = InventoryItemApi[] | InventoryApiEnvelope
+export interface InventoryListApiResponse {
+	data: InventoryItemApi[]
+	pagination: InventoryPagination
+}
 
-function normalizeInventoryResponse(
-	response: InventoryApiResponse
-): InventoryItemApi[] {
-	if (Array.isArray(response)) {
-		return response
+interface InventoryQueryParams {
+	limit?: number
+	offset?: number
+	search?: string
+	category?: string
+	minStock?: number
+	maxStock?: number
+}
+
+interface GetInventoryParams extends InventoryQueryParams {
+	organizationId: string
+	signal?: AbortSignal
+}
+
+function buildInventoryQueryParams(params: InventoryQueryParams): string {
+	const queryParams = new URLSearchParams()
+
+	if (typeof params.limit === "number") {
+		queryParams.set(
+			"limit",
+			Math.min(100, Math.max(1, Math.trunc(params.limit))).toString()
+		)
 	}
 
-	if (Array.isArray(response.inventory)) {
-		return response.inventory
+	if (typeof params.offset === "number") {
+		queryParams.set("offset", Math.max(0, Math.trunc(params.offset)).toString())
 	}
 
-	if (Array.isArray(response.items)) {
-		return response.items
+	if (params.search?.trim()) {
+		queryParams.set("search", params.search.trim())
 	}
 
-	if (Array.isArray(response.data)) {
-		return response.data
+	if (params.category?.trim()) {
+		queryParams.set("category", params.category.trim())
 	}
 
-	return []
+	if (typeof params.minStock === "number") {
+		queryParams.set("minStock", Math.max(0, params.minStock).toString())
+	}
+
+	if (typeof params.maxStock === "number") {
+		queryParams.set("maxStock", Math.max(0, params.maxStock).toString())
+	}
+
+	return queryParams.toString()
 }
 
 export function mapInventoryApiToInventoryItem(
@@ -55,25 +83,23 @@ export function mapInventoryApiToInventoryItem(
 }
 
 export async function getInventory(
-	organizationId: string,
-	signal?: AbortSignal
-): Promise<InventoryItemApi[]> {
-	const response = await apiFetch<InventoryApiResponse>(
-		`/inventory/${organizationId}`,
-		{ signal }
-	)
+	params: GetInventoryParams
+): Promise<InventoryListApiResponse> {
+	const queryString = buildInventoryQueryParams(params)
+	const endpoint = `/inventory/${params.organizationId}${queryString ? `?${queryString}` : ""}`
 
-	return normalizeInventoryResponse(response)
+	return await apiFetch<InventoryListApiResponse>(endpoint, {
+		signal: params.signal,
+	})
 }
 
 export async function getInventoryLowStock(
-	organizationId: string,
-	signal?: AbortSignal
-): Promise<InventoryItemApi[]> {
-	const response = await apiFetch<InventoryApiResponse>(
-		`/inventory/${organizationId}/low-stock`,
-		{ signal }
-	)
+	params: GetInventoryParams
+): Promise<InventoryListApiResponse> {
+	const queryString = buildInventoryQueryParams(params)
+	const endpoint = `/inventory/${params.organizationId}/low-stock${queryString ? `?${queryString}` : ""}`
 
-	return normalizeInventoryResponse(response)
+	return await apiFetch<InventoryListApiResponse>(endpoint, {
+		signal: params.signal,
+	})
 }

--- a/src/domains/inventory/hooks/use-inventory-query-keys.ts
+++ b/src/domains/inventory/hooks/use-inventory-query-keys.ts
@@ -1,9 +1,62 @@
 export const inventoryQueryKeys = {
 	all: ["inventory"] as const,
-	lists: (organizationId: string | null | undefined) =>
-		[...inventoryQueryKeys.all, "list", { organizationId }] as const,
-	list: (organizationId: string | null | undefined) =>
-		[...inventoryQueryKeys.lists(organizationId)] as const,
-	lowStock: (organizationId: string | null | undefined) =>
-		[...inventoryQueryKeys.all, "low-stock", { organizationId }] as const,
+	lists: (
+		organizationId: string | null | undefined,
+		params: {
+			limit: number
+			offset: number
+			search?: string
+			category?: string
+			minStock?: number
+			maxStock?: number
+		}
+	) =>
+		[
+			...inventoryQueryKeys.all,
+			"list",
+			{
+				organizationId,
+				limit: params.limit,
+				offset: params.offset,
+				search: params.search || null,
+				category: params.category || null,
+				minStock: params.minStock ?? null,
+				maxStock: params.maxStock ?? null,
+			},
+		] as const,
+	list: (
+		organizationId: string | null | undefined,
+		params: {
+			limit: number
+			offset: number
+			search?: string
+			category?: string
+			minStock?: number
+			maxStock?: number
+		}
+	) => [...inventoryQueryKeys.lists(organizationId, params)] as const,
+	lowStock: (
+		organizationId: string | null | undefined,
+		params: {
+			limit: number
+			offset: number
+			search?: string
+			category?: string
+			minStock?: number
+			maxStock?: number
+		}
+	) =>
+		[
+			...inventoryQueryKeys.all,
+			"low-stock",
+			{
+				organizationId,
+				limit: params.limit,
+				offset: params.offset,
+				search: params.search || null,
+				category: params.category || null,
+				minStock: params.minStock ?? null,
+				maxStock: params.maxStock ?? null,
+			},
+		] as const,
 }

--- a/src/domains/inventory/hooks/use-inventory.ts
+++ b/src/domains/inventory/hooks/use-inventory.ts
@@ -2,37 +2,109 @@ import { useQuery } from "@tanstack/react-query"
 import {
 	getInventory,
 	getInventoryLowStock,
+	type InventoryListApiResponse,
+	type InventoryPagination,
 	mapInventoryApiToInventoryItem,
 } from "../api/inventory-api"
-import type {
-	InventoryItem,
-	InventoryItemApi,
-} from "../types/inventory-item-types"
+import type { InventoryItem } from "../types/inventory-item-types"
 import { inventoryQueryKeys } from "./use-inventory-query-keys"
 
-export function useInventory(organizationId: string | null | undefined) {
-	return useQuery<InventoryItemApi[], Error, InventoryItem[]>({
-		queryKey: inventoryQueryKeys.list(organizationId),
-		queryFn: ({ signal }) => getInventory(organizationId as string, signal),
+export interface InventoryFilters {
+	search?: string
+	category?: string
+	minStock?: number
+	maxStock?: number
+}
+
+interface UseInventoryParams extends InventoryFilters {
+	organizationId: string | null | undefined
+	limit?: number
+	offset?: number
+}
+
+export interface InventoryListResult {
+	items: InventoryItem[]
+	pagination: InventoryPagination
+}
+
+export function useInventory({
+	organizationId,
+	limit = 20,
+	offset = 0,
+	search,
+	category,
+	minStock,
+	maxStock,
+}: UseInventoryParams) {
+	return useQuery<InventoryListApiResponse, Error, InventoryListResult>({
+		queryKey: inventoryQueryKeys.list(organizationId, {
+			limit,
+			offset,
+			search,
+			category,
+			minStock,
+			maxStock,
+		}),
+		queryFn: ({ signal }) =>
+			getInventory({
+				organizationId: organizationId as string,
+				limit,
+				offset,
+				search,
+				category,
+				minStock,
+				maxStock,
+				signal,
+			}),
 		enabled: Boolean(organizationId),
 		refetchInterval: 60_000,
 		staleTime: 30_000,
 		refetchOnWindowFocus: true,
-		select: (items) => items.map(mapInventoryApiToInventoryItem),
+		select: (response) => ({
+			items: response.data.map(mapInventoryApiToInventoryItem),
+			pagination: response.pagination,
+		}),
 	})
 }
 
-export function useInventoryLowStock(
-	organizationId: string | null | undefined
-) {
-	return useQuery<InventoryItemApi[], Error, InventoryItem[]>({
-		queryKey: inventoryQueryKeys.lowStock(organizationId),
+export function useInventoryLowStock(params: UseInventoryParams) {
+	const {
+		organizationId,
+		limit = 20,
+		offset = 0,
+		search,
+		category,
+		minStock,
+		maxStock,
+	} = params
+
+	return useQuery<InventoryListApiResponse, Error, InventoryListResult>({
+		queryKey: inventoryQueryKeys.lowStock(organizationId, {
+			limit,
+			offset,
+			search,
+			category,
+			minStock,
+			maxStock,
+		}),
 		queryFn: ({ signal }) =>
-			getInventoryLowStock(organizationId as string, signal),
+			getInventoryLowStock({
+				organizationId: organizationId as string,
+				limit,
+				offset,
+				search,
+				category,
+				minStock,
+				maxStock,
+				signal,
+			}),
 		enabled: Boolean(organizationId),
 		refetchInterval: 60_000,
 		staleTime: 30_000,
 		refetchOnWindowFocus: true,
-		select: (items) => items.map(mapInventoryApiToInventoryItem),
+		select: (response) => ({
+			items: response.data.map(mapInventoryApiToInventoryItem),
+			pagination: response.pagination,
+		}),
 	})
 }


### PR DESCRIPTION
## Contexto

O backend de inventário foi atualizado para retorno paginado (`data` + `pagination`) e suporte a query params de filtro. Este PR finaliza o front para consumir o novo contrato em listagem e low-stock.

## O que mudou

- Ajustado `inventory-api` para consumir resposta paginada com `data` e `pagination`.
- Adicionado suporte a query params em listagem/low-stock: `limit`, `offset`, `search`, `category`, `minStock`, `maxStock`.
- Refatorado `useInventory` e `useInventoryLowStock` para retornar `{ items, pagination }`.
- Atualizadas query keys de inventário para incluir paginação e filtros no cache key.
- Atualizada tela `inventory.tsx` para busca server-side com debounce, paginação, filtro por categoria server-side e contadores baseados em `pagination.total`.
- Mantidos estados de loading, vazio, erro e retry.
- Closes #75

## Como validar

1. `pnpm build`
2. `pnpm check`
3. `pnpm pr_ready`
4. Validacao funcional/manual (descrever)
   - Validar paginação com botões Anterior/Próxima.
   - Validar busca server-side (`search`) na listagem.
   - Validar filtro por categoria via API.
   - Validar contador de low-stock via `pagination.total` do endpoint de alertas.

## Checklist geral

- [x] Texto user-facing em pt-BR.
- [x] Sem codigo morto e sem import nao utilizado.
- [x] Sem alteracao fora do escopo.

## Checklist de arquitetura

- [x] Respeita fronteiras `app/domains/shared`.
- [x] Sem import cruzado direto entre dominios.
- [x] Naming e paths seguem `docs/naming.md` e `docs/architecture.md`.
- [x] Tipos cross-domain estao em `shared/types`.
- [ ] Quando houve migracao, `docs/architecture.md` foi atualizado.

## Checklist modulo sem mock (quando aplicavel)

- [x] Sem fallback silencioso para `mock-data` no modulo.
- [x] Query keys e endpoint segregados por `organizationId`.
- [x] Estados de loading, vazio, erro e retry implementados.
- [x] Erros com impacto para usuario tratados com `toast.error` + `sentryCaptureException`.
- [x] Contrato validado (campos, paginacao, filtros) com front e back.
- [x] DoD aplicado conforme `docs/dod-modulo-sem-mock.md`.